### PR TITLE
feat: Integrate Bible dictionary functionality

### DIFF
--- a/assets/css/dictionary-styles.css
+++ b/assets/css/dictionary-styles.css
@@ -1,0 +1,136 @@
+/* Dictionary Term Styles */
+.dict-term {
+    border-bottom: 1px dotted #000; /* Or a color that fits the theme */
+    cursor: help;
+    position: relative; /* Useful if tooltip positioning is relative to the term */
+}
+
+body.dark-mode .dict-term {
+    border-bottom-color: #ccc; /* Lighter dotted line for dark mode */
+}
+
+#bible-dictionary-tooltip {
+    background-color: #f9f9f9;
+    color: #333;
+    border: 1px solid #ccc;
+    padding: 10px 15px; /* Increased padding slightly */
+    border-radius: 6px; /* Slightly more rounded */
+    box-shadow: 0 4px 8px rgba(0,0,0,0.15); /* Enhanced shadow */
+    max-width: 320px; /* Slightly wider */
+    font-size: 0.9em;
+    line-height: 1.5; /* Adjusted line height */
+    /* Ensure it's not selectable if it gets in the way, though this is usually not an issue for hover tooltips */
+    user-select: none;
+    pointer-events: none; /* So tooltip itself doesn't interfere with mouse events on elements below it */
+}
+
+body.dark-mode #bible-dictionary-tooltip {
+    background-color: #333; /* Dark background */
+    color: #f0f0f0; /* Light text */
+    border-color: #555; /* Darker border */
+}
+
+/* Modal Basic Styles for Chapter Meanings */
+#bible-chapter-meanings-modal {
+    position: fixed; /* Stay in place */
+    z-index: 1001; /* Sit on top, above tooltip */
+    left: 0;
+    top: 0;
+    width: 100%; /* Full width */
+    height: 100%; /* Full height */
+    overflow: auto; /* Enable scroll if needed */
+    background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+    display: none; /* Hidden by default */
+    align-items: center; /* For vertical centering of content */
+    justify-content: center; /* For horizontal centering of content */
+}
+
+#bible-chapter-meanings-modal .modal-content {
+    background-color: #fefefe;
+    margin: auto; /* Centered by flex align/justify on parent */
+    padding: 25px;
+    border: 1px solid #888;
+    width: 85%;
+    max-width: 650px; /* Max width */
+    border-radius: 8px;
+    position: relative;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+    max-height: 80vh; /* Max height */
+    display: flex;
+    flex-direction: column;
+}
+
+#bible-chapter-meanings-modal .modal-content h2 {
+    margin-top: 0;
+    margin-bottom: 15px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #eee;
+    font-size: 1.5em;
+    color: #333;
+}
+
+#bible-chapter-meanings-modal .meanings-list {
+    overflow-y: auto; /* Scrollable list */
+    flex-grow: 1; /* Takes available space */
+}
+
+#bible-chapter-meanings-modal .close-button {
+    color: #aaa;
+    position: absolute; /* Position relative to modal-content */
+    top: 10px;
+    right: 15px;
+    font-size: 30px;
+    font-weight: bold;
+    line-height: 1;
+}
+
+#bible-chapter-meanings-modal .close-button:hover,
+#bible-chapter-meanings-modal .close-button:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+#bible-chapter-meanings-modal .meanings-list ul {
+    list-style-type: none;
+    padding-left: 0;
+    margin: 0;
+}
+
+#bible-chapter-meanings-modal .meanings-list li {
+    padding: 10px 5px;
+    border-bottom: 1px solid #f0f0f0;
+    font-size: 0.95em;
+}
+
+#bible-chapter-meanings-modal .meanings-list li:last-child {
+    border-bottom: none;
+}
+
+#bible-chapter-meanings-modal .meanings-list li strong {
+    color: var(--primary-color, #2563eb); /* Use plugin's primary color if defined */
+}
+
+/* Dark mode for modal */
+body.dark-mode #bible-chapter-meanings-modal .modal-content {
+    background-color: #2d3748; /* Darker background for modal content */
+    color: #e2e8f0; /* Lighter text for modal content */
+    border-color: #4a5568;
+}
+body.dark-mode #bible-chapter-meanings-modal .modal-content h2 {
+    color: #e2e8f0;
+    border-bottom-color: #4a5568;
+}
+body.dark-mode #bible-chapter-meanings-modal .close-button {
+    color: #a0aec0;
+}
+body.dark-mode #bible-chapter-meanings-modal .close-button:hover,
+body.dark-mode #bible-chapter-meanings-modal .close-button:focus {
+    color: #e2e8f0;
+}
+body.dark-mode #bible-chapter-meanings-modal .meanings-list li {
+    border-bottom-color: #4a5568;
+}
+body.dark-mode #bible-chapter-meanings-modal .meanings-list li strong {
+    color: var(--accent-color, #f59e0b); /* Use plugin's accent color in dark mode if defined */
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -8,22 +8,45 @@ if (!defined('ABSPATH')) {
 
 if (!function_exists('my_bible_get_controls_html')) {
     function my_bible_get_controls_html($context = 'content', $verse_object = null, $verse_reference_text = '') {
-        $unique_id_suffix = '-' . uniqid(); 
+        $unique_id_suffix = '-' . uniqid();
         if ($context === 'content' || $context === 'search') {
-            $unique_id_suffix = ($context === 'search') ? '-search' : '';
+            // For 'content' and 'search' (full chapter in search), use a consistent suffix or none if IDs should be static for these contexts
+            // For simplicity, if these are unique major blocks, a static ID might be okay, or a context-based suffix.
+            // Let's use a predictable suffix for these primary views if needed, or keep unique if multiple instances can occur.
+            // The original logic used -search for search, and empty for content. Let's refine.
+            if ($context === 'search' && $verse_object) { // Single verse in search result
+                 $unique_id_suffix = '-sv-' . uniqid(); // Unique for single verse results
+            } elseif ($context === 'search') { // Full chapter view in search
+                 $unique_id_suffix = '-search-chap';
+            } elseif ($context === 'content') {
+                 $unique_id_suffix = '-content-chap';
+            }
+            // For random_verse, daily_verse, they are typically single instances on a page, so unique_id is fine.
         }
 
+
         $controls_html = '<div class="bible-controls-wrapper">';
-        
+
         $controls_html .= '<div class="bible-main-controls">';
         $controls_html .= '<button id="toggle-tashkeel' . esc_attr($unique_id_suffix) . '" class="bible-control-button" data-action="toggle-tashkeel"><i class="fas fa-language"></i> <span class="label">' . esc_html__('إلغاء التشكيل', 'my-bible-plugin') . '</span></button>';
         $controls_html .= '<button id="increase-font' . esc_attr($unique_id_suffix) . '" class="bible-control-button" data-action="increase-font"><i class="fas fa-plus"></i> <span class="label">' . esc_html__('تكبير الخط', 'my-bible-plugin') . '</span></button>';
         $controls_html .= '<button id="decrease-font' . esc_attr($unique_id_suffix) . '" class="bible-control-button" data-action="decrease-font"><i class="fas fa-minus"></i> <span class="label">' . esc_html__('تصغير الخط', 'my-bible-plugin') . '</span></button>';
-        
-        $dark_mode_button_id = ($context === 'content' || $context === 'search') ? 'dark-mode-toggle' : 'dark-mode-toggle' . esc_attr($unique_id_suffix);
+
+        // Use a consistent ID for the main dark mode toggle if it's unique per page load, or suffix if multiple control sets exist
+        $dark_mode_button_id = 'dark-mode-toggle' . esc_attr($unique_id_suffix);
+        // However, if there's one global dark mode button expected by JS, its ID should be static.
+        // Assuming the JS targets '.dark-mode-toggle-button' class for generic behavior and specific IDs for specific instances if needed.
+        // For now, keeping unique IDs for buttons to avoid conflicts if multiple shortcodes are on a page.
         $controls_html .= '<button id="' . esc_attr($dark_mode_button_id) . '" class="bible-control-button dark-mode-toggle-button" data-action="dark-mode-toggle"><i class="fas fa-moon"></i> <span class="label">' . esc_html__('الوضع الليلي', 'my-bible-plugin') . '</span></button>';
         $controls_html .= '<button id="read-aloud-button' . esc_attr($unique_id_suffix) . '" class="bible-control-button read-aloud-button" data-action="read-aloud"><i class="fas fa-volume-up"></i> <span class="label">' . esc_html__('قراءة بصوت عالٍ', 'my-bible-plugin') . '</span></button>';
-        $controls_html .= '</div>'; 
+
+        // Add "Show Meanings for Chapter" button for relevant contexts
+        // $verse_object is null for full chapter display in search results
+        if ($context === 'content' || ($context === 'search' && !$verse_object)) {
+            $controls_html .= '<button id="show-chapter-meanings' . esc_attr($unique_id_suffix) . '" class="bible-control-button" data-action="show-chapter-meanings"><i class="fas fa-book-reader"></i> <span class="label">' . esc_html__('إظهار معاني كلمات الأصحاح', 'my-bible-plugin') . '</span></button>';
+        }
+
+        $controls_html .= '</div>';
 
         $show_image_options_contexts = array('single_verse', 'random_verse', 'daily_verse');
         if (in_array($context, $show_image_options_contexts) && $verse_object && !empty($verse_reference_text)) {
@@ -40,10 +63,10 @@ if (!function_exists('my_bible_get_controls_html')) {
                 $controls_html .= '<select id="bible-image-bg-select' . esc_attr($unique_id_suffix) . '" class="bible-image-select">';
                 $controls_html .= '<option value="">' . esc_html__('اختر الخلفية...', 'my-bible-plugin') . '</option>';
                 $controls_html .= '</select></div>';
-            $controls_html .= '</div>'; 
-            $controls_html .= '</div>'; 
+            $controls_html .= '</div>';
+            $controls_html .= '</div>';
         }
-        $controls_html .= '</div>'; 
+        $controls_html .= '</div>';
         return $controls_html;
     }
 }
@@ -54,9 +77,12 @@ if (!function_exists('my_bible_sanitize_book_name')) {
         $book_name = (string) $book_name;
         $book_name = trim($book_name);
         $book_name = str_replace('-', ' ', $book_name);
+        // Remove Tashkeel (Arabic diacritics)
         $book_name = preg_replace('/[\x{0617}-\x{061A}\x{064B}-\x{065F}\x{06D6}-\x{06ED}]/u', '', $book_name);
+        // Standardize common Arabic letters (Alef variants to simple Alef, Yaa variants to simple Yaa)
         $book_name = str_replace(array('أ', 'إ', 'آ', 'ٱ', 'أُ', 'إِ'), 'ا', $book_name);
         $book_name = str_replace(array('ى'), 'ي', $book_name);
+        // Remove extra spaces
         $book_name = preg_replace('/\s+/', ' ', $book_name);
         return trim($book_name);
     }
@@ -65,27 +91,33 @@ if (!function_exists('my_bible_sanitize_book_name')) {
 if (!function_exists('my_bible_create_book_slug')) {
     function my_bible_create_book_slug($book_name) {
         if (empty($book_name)) return '';
-        $slug = my_bible_sanitize_book_name($book_name);
-        $slug = str_replace(' ', '-', $slug);
+        $slug = my_bible_sanitize_book_name($book_name); // Sanitize first
+        $slug = str_replace(' ', '-', $slug); // Replace spaces with hyphens
+        // Remove any characters not Arabic, alphanumeric, or hyphen.
         $slug = preg_replace('/[^\p{Arabic}\p{N}a-zA-Z0-9\-]+/u', '', $slug);
-        return rawurlencode($slug);
+        return rawurlencode($slug); // URL encode the final slug
     }
 }
 
+// Function to get the canonical book order for OT and NT
 if (!function_exists('my_bible_get_defined_book_order_within_testaments')) {
     function my_bible_get_defined_book_order_within_testaments() {
         return array(
-            'العهد القديم' => array( 
+            'العهد القديم' => array(
                 'سفر التكوين', 'سفر الخروج', 'سفر اللاويين', 'سفر العدد', 'سفر التثنية',
                 'سفر يشوع', 'سفر القضاة', 'سفر راعوث', 'سفر صموئيل الأول', 'سفر صموئيل الثاني', 'سفر الملوك الأول', 'سفر الملوك الثاني', 'سفر أخبار الأيام الأول', 'سفر أخبار الأيام الثاني', 'سفر عزرا', 'سفر نحميا', 'سفر أستير',
                 'سفر أيوب', 'سفر المزامير', 'سفر الأمثال', 'سفر الجامعة', 'سفر نشيد الأنشاد',
                 'سفر إشعياء', 'سفر إرميا', 'سفر مراثي إرميا', 'سفر حزقيال', 'سفر دانيال',
                 'سفر هوشع', 'سفر يوئيل', 'سفر عاموس', 'سفر عوبديا', 'سفر يونان', 'سفر ميخا', 'سفر ناحوم', 'سفر حبقوق', 'سفر صفنيا', 'سفر حجي', 'سفر زكريا', 'سفر ملاخي'
             ),
-            'العهد الجديد' => array( 
+            'العهد الجديد' => array(
                 'إنجيل متى', 'إنجيل مرقس', 'إنجيل لوقا', 'إنجيل يوحنا',
                 'سفر أعمال الرسل',
-                'رسالة بولس الرسول إلى أهل رومية', 'رسالة بولس الرسول الأولى إلى أهل كورنثوس', 'رسالة بولس الرسول الثانية إلى أهل كورنثوس', 'رسالة بولس الرسول إلى أهل غلاطية', 'رسالة بولس الرسول إلى أهل أفسس', 'رسالة بولس الرسول إلى أهل فيلبي', 'رسالة بولس الرسول إلى أهل كولوسي', 'رسالة بولس الرسول الأولى إلى أهل تسالونيكي', 'رسالة بولس الرسول الثانية إلى أهل تسالونيكي', 'رسالة بولس الرسول الأولى إلى تيموثاوس', 'رسالة بولس الرسول الثانية إلى تيموثاوس', 'رسالة بولس الرسول إلى تيطس', 'رسالة بولس الرسول إلى فليمون',
+                'رسالة بولس الرسول إلى أهل رومية', // Full name for Romans
+                'رسالة بولس الرسول الأولى إلى أهل كورنثوس', 'رسالة بولس الرسول الثانية إلى أهل كورنثوس',
+                'رسالة بولس الرسول إلى أهل غلاطية', 'رسالة بولس الرسول إلى أهل أفسس', 'رسالة بولس الرسول إلى أهل فيلبي', 'رسالة بولس الرسول إلى أهل كولوسي',
+                'رسالة بولس الرسول الأولى إلى أهل تسالونيكي', 'رسالة بولس الرسول الثانية إلى أهل تسالونيكي',
+                'رسالة بولس الرسول الأولى إلى تيموثاوس', 'رسالة بولس الرسول الثانية إلى تيموثاوس', 'رسالة بولس الرسول إلى تيطس', 'رسالة بولس الرسول إلى فليمون',
                 'الرسالة إلى العبرانيين', 'رسالة يعقوب', 'رسالة بطرس الأولى', 'رسالة بطرس الثانية', 'رسالة يوحنا الأولى', 'رسالة يوحنا الثانية', 'رسالة يوحنا الثالثة', 'رسالة يهوذا',
                 'سفر رؤيا يوحنا اللاهوتي'
             )
@@ -93,97 +125,213 @@ if (!function_exists('my_bible_get_defined_book_order_within_testaments')) {
     }
 }
 
+
+// Helper to get book order, respecting defined order first, then remaining DB books
 if (!function_exists('my_bible_get_book_order_from_db')) {
     function my_bible_get_book_order_from_db($testament_value_in_db = 'all') {
-        $cache_key = 'bible_book_order_' . md5(is_string($testament_value_in_db) ? $testament_value_in_db : 'serialized_array');
+        $cache_key = 'bible_book_order_' . md5(is_string($testament_value_in_db) ? $testament_value_in_db : 'serialized_array_or_obj'); // More robust cache key
         $cached_result = get_transient($cache_key);
         if ($cached_result !== false) { return $cached_result; }
+
         global $wpdb; $table_name = $wpdb->prefix . 'bible_verses'; $where_clause = ''; $prepare_args = array();
+
         if ($testament_value_in_db !== 'all' && !empty($testament_value_in_db)) {
+            // Validate testament against DB values to prevent SQL injection if this value somehow comes from user input without sanitization prior.
             $valid_testaments = $wpdb->get_col("SELECT DISTINCT testament FROM {$table_name} WHERE testament != ''");
-            if (!in_array($testament_value_in_db, $valid_testaments) && $testament_value_in_db !== 'all') {
-                set_transient($cache_key, array(), HOUR_IN_SECONDS); return array(); 
+            if (!in_array($testament_value_in_db, $valid_testaments) && $testament_value_in_db !== 'all') { // also check 'all' for safety, though it means no filter
+                set_transient($cache_key, array(), HOUR_IN_SECONDS); // Cache empty for invalid testament
+                return array();
             }
             $where_clause = "WHERE testament = %s"; $prepare_args[] = $testament_value_in_db;
         }
+
         $defined_order_for_current_testament = array(); $order_by_clause_parts = array();
         $all_defined_orders = my_bible_get_defined_book_order_within_testaments();
+
         if ($testament_value_in_db !== 'all' && isset($all_defined_orders[$testament_value_in_db])) {
             $defined_order_for_current_testament = $all_defined_orders[$testament_value_in_db];
-        } elseif ($testament_value_in_db === 'all') {
+        } elseif ($testament_value_in_db === 'all') { // For 'all', merge OT and NT defined orders
             $ot_order = isset($all_defined_orders['العهد القديم']) ? $all_defined_orders['العهد القديم'] : array();
             $nt_order = isset($all_defined_orders['العهد الجديد']) ? $all_defined_orders['العهد الجديد'] : array();
             $defined_order_for_current_testament = array_merge($ot_order, $nt_order);
         }
+        // Else, if specific testament not in defined_orders (e.g. "أسفار أخرى"), $defined_order_for_current_testament remains empty, will sort by name.
+
         if (!empty($defined_order_for_current_testament)) {
+            // Get books actually in DB for the current testament filter
             $books_in_db_for_testament_query = "SELECT DISTINCT book FROM {$table_name} {$where_clause}";
             if (!empty($prepare_args)) { $books_in_db_for_testament_query = $wpdb->prepare($books_in_db_for_testament_query, $prepare_args); }
             $books_actually_in_db_for_testament = $wpdb->get_col($books_in_db_for_testament_query);
+
             if ($books_actually_in_db_for_testament) {
+                // Filter defined order to only include books present in the DB for this testament
                 $final_ordered_list_from_defined = array_values(array_intersect($defined_order_for_current_testament, $books_actually_in_db_for_testament));
+                // Get any books from DB for this testament not in the defined order (e.g. deuterocanonical if not in primary lists)
                 $remaining_books_in_db = array_diff($books_actually_in_db_for_testament, $final_ordered_list_from_defined);
                 if ($remaining_books_in_db) { sort($remaining_books_in_db); $final_ordered_list_from_defined = array_merge($final_ordered_list_from_defined, $remaining_books_in_db); }
+
                 if (!empty($final_ordered_list_from_defined)) {
                      $order_by_clause_parts[] = "FIELD(book, " . implode(', ', array_map(function($book) use ($wpdb) { return $wpdb->prepare("%s", $book); }, $final_ordered_list_from_defined)) . ")";
                 }
             }
         }
-        $order_by_clause_parts[] = "book ASC"; $order_by_sql = "ORDER BY " . implode(', ', $order_by_clause_parts);
+
+        // Fallback or additional sort criteria
+        $order_by_clause_parts[] = "book ASC"; // Ensures any books not in FIELD() are sorted alphabetically
+        $order_by_sql = "ORDER BY " . implode(', ', $order_by_clause_parts);
+
         $sql = "SELECT DISTINCT book FROM {$table_name} {$where_clause} {$order_by_sql}";
         if(!empty($prepare_args) && !empty($where_clause)){ $sql = $wpdb->prepare($sql, $prepare_args); }
+
         $books = $wpdb->get_col($sql);
-        if ($wpdb->last_error) { my_bible_log_error("DB Error in get_book_order_from_db: " . $wpdb->last_error . " SQL: " . $sql); set_transient($cache_key, array(), HOUR_IN_SECONDS); return array(); }
+
+        if ($wpdb->last_error) {
+            my_bible_log_error("DB Error in get_book_order_from_db: " . $wpdb->last_error . " SQL: " . $sql);
+            set_transient($cache_key, array(), HOUR_IN_SECONDS); // Cache empty on error
+            return array();
+        }
         set_transient($cache_key, $books ? $books : array(), HOUR_IN_SECONDS);
         return $books ? $books : array();
     }
 }
+
+
+// Helper to get book name from slug (more robust)
 if (!function_exists('my_bible_get_book_name_from_slug')) {
     function my_bible_get_book_name_from_slug($book_slug) {
-        global $wpdb; if (empty($book_slug)) return false;
-        $decoded_slug = rawurldecode($book_slug); $table_name = $wpdb->prefix . 'bible_verses';
-        $book_name_try_direct = str_replace('-', ' ', $decoded_slug);
-        $db_book_name = $wpdb->get_var($wpdb->prepare( "SELECT DISTINCT book FROM $table_name WHERE book = %s", $book_name_try_direct ));
+        global $wpdb;
+        if (empty($book_slug)) return false;
+
+        $decoded_slug = rawurldecode($book_slug);
+        $table_name = $wpdb->prefix . 'bible_verses';
+
+        // Try direct match (slug might be the actual book name if it contains no special chars/spaces)
+        $db_book_name = $wpdb->get_var($wpdb->prepare( "SELECT DISTINCT book FROM $table_name WHERE book = %s", $decoded_slug ));
         if ($db_book_name) return $db_book_name;
-        $sanitized_slug_as_name = my_bible_sanitize_book_name($book_name_try_direct);
-        $db_book_name_alt_query = $wpdb->prepare( "SELECT DISTINCT book FROM $table_name WHERE REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE( REPLACE(REPLACE(REPLACE(REPLACE(book, 'أ', 'ا'), 'إ', 'ا'), 'آ', 'ا'), 'ٱ', 'ا'), 'أُ', 'ا'), 'إِ', 'ا'), 'ى', 'ي'), 'ً', ''), 'ٌ', ''), 'ٍ', ''), 'َ', ''), 'ُ', ''), 'ِ', '') = %s LIMIT 1", $sanitized_slug_as_name );
-        $db_book_name_alt = $wpdb->get_var($db_book_name_alt_query);
+
+        // Try replacing hyphens with spaces (common slug format)
+        $book_name_from_hyphenated_slug = str_replace('-', ' ', $decoded_slug);
+        $db_book_name = $wpdb->get_var($wpdb->prepare( "SELECT DISTINCT book FROM $table_name WHERE book = %s", $book_name_from_hyphenated_slug ));
+        if ($db_book_name) return $db_book_name;
+
+        // Try matching against sanitized version (as created by my_bible_create_book_slug before urlencode)
+        // This handles cases where the slug was created from a sanitized name
+        $sanitized_input_name = my_bible_sanitize_book_name($book_name_from_hyphenated_slug); // Sanitize the space-replaced slug
+
+        // Query by comparing sanitized book names (remove Alef variants, Yaa, Tashkeel, then spaces)
+        // This query attempts to match the DB book name after it undergoes the same sanitization process as the slug would have
+        $db_book_name_alt = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT DISTINCT book FROM $table_name WHERE
+                REPLACE(
+                    REPLACE(
+                        REPLACE(
+                            REPLACE(
+                                REPLACE(
+                                    REPLACE(
+                                        REPLACE(
+                                            REPLACE(
+                                                REPLACE(
+                                                    REPLACE(
+                                                        REPLACE(
+                                                            REPLACE(
+                                                                REPLACE(book, 'أ', 'ا'),
+                                                            'إ', 'ا'),
+                                                        'آ', 'ا'),
+                                                    'ٱ', 'ا'),
+                                                'أُ', 'ا'),
+                                            'إِ', 'ا'),
+                                        'ى', 'ي'),
+                                    'ً', ''),
+                                'ٌ', ''),
+                            'ٍ', ''),
+                        'َ', ''),
+                    'ُ', ''),
+                'ِ', '') = %s LIMIT 1",
+                $sanitized_input_name // Compare against the sanitized input
+            )
+        );
         if ($db_book_name_alt) return $db_book_name_alt;
+
+        // Fallback: if no numbers in slug, try LIKE query (less precise)
         if (!preg_match('/\d/', $decoded_slug)) {
-            $possible_books = $wpdb->get_results($wpdb->prepare( "SELECT DISTINCT book FROM $table_name WHERE book LIKE %s", '%' . $wpdb->esc_like($book_name_try_direct) . '%' ));
+            $possible_books = $wpdb->get_results($wpdb->prepare( "SELECT DISTINCT book FROM $table_name WHERE book LIKE %s", '%' . $wpdb->esc_like($book_name_from_hyphenated_slug) . '%' ));
             if (count($possible_books) === 1) { return $possible_books[0]->book; }
         }
-        return false;
+        if (function_exists('my_bible_log_error')) my_bible_log_error("Book slug not resolved: " . $book_slug, 'slug_resolution');
+        return false; // No match found
     }
 }
+
+
+// Helper to parse reference string (e.g., "يوحنا 3:16" or "1كو 13")
 if (!function_exists('my_bible_parse_reference')) {
     function my_bible_parse_reference($reference_string) {
         $reference_string = trim($reference_string);
         $parsed = array('book' => null, 'chapter' => null, 'verse' => null, 'is_reference' => false);
+
+        // Regex: Catches book name (can have numbers like "1" or "2" and spaces), chapter, and optional verse
+        // Allows for various separators like space, colon, period between chapter and verse.
         if (preg_match('/^([0-9]?\s*[^\d\s]+(?:\s+[^\d\s]+)*)\s*([0-9]+)(?:[\s:.]*\s*([0-9]+))?$/u', $reference_string, $matches)) {
-            $book_name_input = trim($matches[1]); $chapter_num = intval($matches[2]);
+            $book_name_input = trim($matches[1]);
+            $chapter_num = intval($matches[2]);
             $verse_num = isset($matches[3]) && !empty($matches[3]) ? intval($matches[3]) : null;
-            global $wpdb; $table_name = $wpdb->prefix . 'bible_verses';
+
+            global $wpdb;
+            $table_name = $wpdb->prefix . 'bible_verses';
+
+            // Attempt 1: Direct match of book name input
             $db_book_name = $wpdb->get_var($wpdb->prepare("SELECT DISTINCT book FROM $table_name WHERE book = %s", $book_name_input));
+
+            // Attempt 2: Match against sanitized book name (common for abbreviations like "تك" vs "سفر التكوين")
             if (!$db_book_name) {
                 $sanitized_input_book = my_bible_sanitize_book_name($book_name_input);
-                 $db_book_name = $wpdb->get_var($wpdb->prepare( "SELECT DISTINCT book FROM $table_name WHERE REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE( REPLACE(REPLACE(REPLACE(REPLACE(book, 'أ', 'ا'), 'إ', 'ا'), 'آ', 'ا'), 'ٱ', 'ا'), 'أُ', 'ا'), 'إِ', 'ا'), 'ى', 'ي'), 'ً', ''), 'ٌ', ''), 'ٍ', ''), 'َ', ''), 'ُ', ''), 'ِ', '') = %s", $sanitized_input_book));
+                // This complex REPLACE sequence in SQL is to mimic parts of my_bible_sanitize_book_name on the DB side for comparison
+                $db_book_name = $wpdb->get_var($wpdb->prepare(
+                    "SELECT DISTINCT book FROM $table_name WHERE
+                    REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                    REPLACE(REPLACE(REPLACE(REPLACE(book, 'أ', 'ا'), 'إ', 'ا'), 'آ', 'ا'), 'ٱ', 'ا'),
+                    'أُ', 'ا'), 'إِ', 'ا'), 'ى', 'ي'),
+                    'ً', ''), 'ٌ', ''), 'ٍ', ''),
+                    'َ', ''), 'ُ', ''), 'ِ', '') = %s", $sanitized_input_book));
             }
+
+            // Attempt 3: Handle cases like "1 مل" or "2 صم" where the number is part of the input
             if (!$db_book_name && preg_match('/^([0-9]+)\s+(.+)$/u', $book_name_input, $book_parts)) {
-                $number_map_to_text = array('1' => 'الأول', '2' => 'الثاني', '3' => 'الثالث');
-                $numeric_prefix_num = $book_parts[1]; $book_base_name = trim($book_parts[2]);
-                $possible_books_query = $wpdb->prepare( "SELECT DISTINCT book FROM $table_name WHERE book LIKE %s AND book LIKE %s", '%' . $wpdb->esc_like($book_base_name) . '%', isset($number_map_to_text[$numeric_prefix_num]) ? '%' . $wpdb->esc_like($number_map_to_text[$numeric_prefix_num]) . '%' : '% %' );
-                $possible_books = $wpdb->get_col($possible_books_query);
-                if (count($possible_books) === 1) { $db_book_name = $possible_books[0];
-                } elseif (count($possible_books) > 1) {
-                    foreach ($possible_books as $possible_book) {
-                        if (isset($number_map_to_text[$numeric_prefix_num]) && (strpos($possible_book, $number_map_to_text[$numeric_prefix_num] . ' ' . $book_base_name) !== false || strpos($possible_book, $book_base_name . ' ' . $number_map_to_text[$numeric_prefix_num]) !== false || strpos($possible_book, $book_base_name . $number_map_to_text[$numeric_prefix_num]) !== false )) {
-                            $db_book_name = $possible_book; break;
+                $number_map_to_text = array('1' => 'الأول', '2' => 'الثاني', '3' => 'الثالث'); // Expand as needed
+                $numeric_prefix_num_str = $book_parts[1];
+                $book_base_name = trim($book_parts[2]);
+                $textual_prefix = isset($number_map_to_text[$numeric_prefix_num_str]) ? $number_map_to_text[$numeric_prefix_num_str] : null;
+
+                if($textual_prefix){
+                    // Search for "الاسم اللفظي السفر" e.g. "صموئيل الأول" or "الملوك الثاني"
+                    $possible_books_query = $wpdb->prepare(
+                        "SELECT DISTINCT book FROM $table_name WHERE book LIKE %s AND book LIKE %s",
+                        '%' . $wpdb->esc_like($book_base_name) . '%',
+                        '%' . $wpdb->esc_like($textual_prefix) . '%'
+                    );
+                    $possible_books = $wpdb->get_col($possible_books_query);
+
+                    if (count($possible_books) === 1) {
+                        $db_book_name = $possible_books[0];
+                    } elseif (count($possible_books) > 1) {
+                        // Try to find a more exact match if multiple books share the base name
+                        foreach ($possible_books as $possible_book) {
+                            // Check for patterns like "سفر صموئيل الأول" or "صموئيل الأول"
+                            if (strpos($possible_book, $book_base_name . ' ' . $textual_prefix) !== false ||
+                                strpos($possible_book, $textual_prefix . ' ' . $book_base_name) !== false ) { // Less common but possible
+                                $db_book_name = $possible_book;
+                                break;
+                            }
                         }
                     }
                 }
             }
+
+            // Final check: if a book name was found and chapter is positive
             if ($db_book_name && $chapter_num > 0) {
-                $parsed['book'] = $db_book_name; $parsed['chapter'] = $chapter_num;
+                $parsed['book'] = $db_book_name; // Use the name as stored in DB
+                $parsed['chapter'] = $chapter_num;
                 $parsed['verse'] = ($verse_num !== null && $verse_num > 0) ? $verse_num : null;
                 $parsed['is_reference'] = true;
             }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -29,6 +29,7 @@ function my_bible_display_content_shortcode($atts) {
     $initial_selected_book_name = '';
     $initial_selected_chapter_number = 0;
     $data_current_testament_attr = '';
+    $dictionary_terms_for_chapter = array(); // Initialize dictionary terms array
 
     if (!empty($atts['book'])) {
         $initial_selected_book_name = $atts['book'];
@@ -56,6 +57,29 @@ function my_bible_display_content_shortcode($atts) {
             }
             $data_current_testament_attr = ' data-current-testament="' . esc_attr($testament_of_initial_book) . '"';
         }
+
+        // Fetch dictionary terms for the initially selected chapter
+        $dict_table_name = $wpdb->prefix . 'bible_dictionary';
+        $normalized_book_name_for_dict_query = '';
+        if (function_exists('my_bible_sanitize_book_name')) {
+            $normalized_book_name_for_dict_query = str_replace(' ', '', my_bible_sanitize_book_name($initial_selected_book_name));
+        } else {
+            $normalized_book_name_for_dict_query = str_replace(' ', '', $initial_selected_book_name);
+            if (function_exists('my_bible_log_error')) my_bible_log_error("my_bible_sanitize_book_name function not found in shortcodes.php for dictionary query (bible_content).", 'dictionary_highlight');
+        }
+
+        if (!empty($normalized_book_name_for_dict_query)) {
+            $dictionary_terms_for_chapter = $wpdb->get_results($wpdb->prepare(
+                "SELECT word, meaning FROM %i WHERE book_name = %s AND chapter = %d",
+                $dict_table_name,
+                $normalized_book_name_for_dict_query,
+                $initial_selected_chapter_number
+            ));
+            if ($wpdb->last_error) {
+                if (function_exists('my_bible_log_error')) my_bible_log_error("DB error fetching dictionary terms for chapter (bible_content): " . $wpdb->last_error, 'dictionary_highlight');
+                $dictionary_terms_for_chapter = array();
+            }
+        }
     }
 
     $books_for_dropdown = array();
@@ -64,6 +88,7 @@ function my_bible_display_content_shortcode($atts) {
     }
 
     $output = '<div id="bible-container" class="bible-content-area">';
+    // ... (rest of the dropdowns and controls HTML generation) ...
     $output .= '<div class="bible-selection-controls-wrapper">';
     $output .= '<div class="bible-selection-controls testament-filter-controls">';
     $output .= '<label for="bible-testament-select">' . esc_html__('اختر العهد:', 'my-bible-plugin') . ' </label>';
@@ -103,7 +128,7 @@ function my_bible_display_content_shortcode($atts) {
         }
     }
     $output .= '</select></div>';
-    $output .= '</div>';
+    $output .= '</div>'; // end bible-selection-controls-wrapper
 
     $output .= '<div id="bible-verses-display" class="bible-verses-content">';
     if (!empty($initial_selected_book_name) && $initial_selected_chapter_number > 0 && !empty($books_for_dropdown) && in_array($initial_selected_book_name, $books_for_dropdown)) {
@@ -118,12 +143,25 @@ function my_bible_display_content_shortcode($atts) {
                 $reference = esc_html($verse_obj->book . ' ' . $verse_obj->chapter . ':' . $verse_obj->verse);
                 $book_slug_for_url = function_exists('my_bible_create_book_slug') ? my_bible_create_book_slug($verse_obj->book) : sanitize_title($verse_obj->book);
                 $verse_url = esc_url(home_url($base_bible_page_uri_sc . $book_slug_for_url . "/{$verse_obj->chapter}/{$verse_obj->verse}/"));
+
+                $modified_verse_text = $verse_obj->text;
+                if (!empty($dictionary_terms_for_chapter)) {
+                    foreach ($dictionary_terms_for_chapter as $dict_term) {
+                        $term_word = $dict_term->word;
+                        $term_meaning = $dict_term->meaning;
+                        $pattern = '/\b(' . preg_quote($term_word, '/') . ')\b/ui';
+                        $replacement = '<span class="dict-term" data-meaning="' . esc_attr($term_meaning) . '">$1</span>';
+                        $modified_verse_text = preg_replace($pattern, $replacement, $modified_verse_text, 1);
+                    }
+                }
+
                 $output .= "<p class='verse-text' data-original-text='" . esc_attr($verse_obj->text) . "' data-verse-url='" . esc_attr($verse_url) . "'>";
                 $output .= "<a href='" . esc_url($verse_url) . "' class='verse-number ajax-nav-link-verse' data-book='".esc_attr($verse_obj->book)."' data-chapter='".esc_attr($verse_obj->chapter)."' data-verse='".esc_attr($verse_obj->verse)."'>" . esc_html($verse_obj->verse) . ".</a> ";
-                $output .= "<span class='text-content'>" . esc_html($verse_obj->text) . "</span> ";
+                $output .= "<span class='text-content'>" . wp_kses_post($modified_verse_text) . "</span> "; // Use wp_kses_post
                 $output .= "<a href='" . esc_url($verse_url) . "' class='verse-reference-link ajax-nav-link-verse' data-book='".esc_attr($verse_obj->book)."' data-chapter='".esc_attr($verse_obj->chapter)."' data-verse='".esc_attr($verse_obj->verse)."'>[" . $reference . "]</a></p>";
             }
             $output .= '</div>';
+            // ... (rest of the chapter navigation) ...
             $all_chapters_for_book = $wpdb->get_col($wpdb->prepare("SELECT DISTINCT chapter FROM $table_name WHERE book = %s ORDER BY chapter ASC", $initial_selected_book_name));
             $current_chapter_idx = array_search($initial_selected_chapter_number, $all_chapters_for_book);
             $book_slug_for_nav = function_exists('my_bible_create_book_slug') ? my_bible_create_book_slug($initial_selected_book_name) : sanitize_title($initial_selected_book_name);
@@ -145,7 +183,7 @@ function my_bible_display_content_shortcode($atts) {
     } else {
         $output .= '<p class="bible-select-prompt">' . esc_html__('يرجى اختيار العهد ثم السفر ثم الأصحاح لعرض الآيات.', 'my-bible-plugin') . '</p>';
     }
-    $output .= '</div></div>'; 
+    $output .= '</div></div>';
     return $output;
 }
 add_shortcode('bible_content', 'my_bible_display_content_shortcode');
@@ -153,6 +191,7 @@ add_shortcode('bible_content', 'my_bible_display_content_shortcode');
 function my_bible_search_form_shortcode($atts) {
     global $wpdb;
     $table_name = $wpdb->prefix . 'bible_verses';
+    $dict_table_name = $wpdb->prefix . 'bible_dictionary'; // Define dict table name
     $options = get_option('my_bible_options');
     $default_testament_search_db = isset($options['default_testament_view_db']) ? $options['default_testament_view_db'] : 'all';
 
@@ -160,6 +199,7 @@ function my_bible_search_form_shortcode($atts) {
     $search_term_get = isset($_GET['bible_search']) ? sanitize_text_field(wp_unslash($_GET['bible_search'])) : '';
     $search_testament_filter_db = isset($_GET['search_testament']) ? sanitize_text_field($_GET['search_testament']) : $default_testament_search_db;
 
+    // ... (form HTML generation as before) ...
     $db_testaments_for_search_select = $wpdb->get_col("SELECT DISTINCT testament FROM " . $wpdb->prefix . "bible_verses WHERE testament != '' ORDER BY testament ASC");
     $allowed_search_testaments = array_merge(array('all'), $db_testaments_for_search_select ? $db_testaments_for_search_select : array());
     if (!in_array($search_testament_filter_db, $allowed_search_testaments)) {
@@ -185,18 +225,41 @@ function my_bible_search_form_shortcode($atts) {
     $output .= '</div>';
     $output .= '</form>';
 
+
     if (!empty($search_term_get)) {
         $output .= '<div class="bible-search-results bible-content-area">';
         $parsed_ref = function_exists('my_bible_parse_reference') ? my_bible_parse_reference($search_term_get) : array('is_reference' => false);
         $base_bible_page_uri_search = trailingslashit(get_page_by_path('bible') ? get_page_uri(get_page_by_path('bible')->ID) : 'bible');
 
         if ($parsed_ref['is_reference']) {
-            $book_name = $parsed_ref['book'];
+            $book_name = $parsed_ref['book']; // This is already normalized by my_bible_parse_reference
             $chapter_num = $parsed_ref['chapter'];
             $verse_num = $parsed_ref['verse'];
-            if ($verse_num) {
+
+            // Normalize book name for dictionary query (remove spaces from the already canonical name from parser)
+            $normalized_book_name_for_dict_query = str_replace(' ', '', $book_name);
+
+            if ($verse_num) { // Single verse display
                 $verse_object = $wpdb->get_row($wpdb->prepare( "SELECT book, chapter, verse, text FROM $table_name WHERE book = %s AND chapter = %d AND verse = %d", $book_name, $chapter_num, $verse_num ));
                 if ($verse_object) {
+                    $dictionary_terms_for_single_verse = array();
+                    if (!empty($normalized_book_name_for_dict_query)) {
+                        $dictionary_terms_for_single_verse = $wpdb->get_results($wpdb->prepare(
+                            "SELECT word, meaning FROM %i WHERE book_name = %s AND chapter = %d AND verse = %d",
+                            $dict_table_name, $normalized_book_name_for_dict_query, $verse_object->chapter, $verse_object->verse
+                        ));
+                        if ($wpdb->last_error) { if (function_exists('my_bible_log_error')) my_bible_log_error("DB error fetching dictionary terms for single verse (search ref): " . $wpdb->last_error, 'dictionary_highlight'); $dictionary_terms_for_single_verse = array(); }
+                    }
+
+                    $modified_verse_text = $verse_object->text;
+                    if (!empty($dictionary_terms_for_single_verse)) {
+                        foreach ($dictionary_terms_for_single_verse as $dict_term) {
+                            $pattern = '/\b(' . preg_quote($dict_term->word, '/') . ')\b/ui';
+                            $replacement = '<span class="dict-term" data-meaning="' . esc_attr($dict_term->meaning) . '">$1</span>';
+                            $modified_verse_text = preg_replace($pattern, $replacement, $modified_verse_text, 1);
+                        }
+                    }
+
                     $reference_text = esc_html($verse_object->book . ' ' . $verse_object->chapter . ':' . $verse_object->verse);
                     $output .= '<h2>' . sprintf(esc_html__('عرض الشاهد: %s', 'my-bible-plugin'), $reference_text) . '</h2>';
                     if (function_exists('my_bible_get_controls_html')) {
@@ -206,14 +269,23 @@ function my_bible_search_form_shortcode($atts) {
                     $book_slug_for_url = function_exists('my_bible_create_book_slug') ? my_bible_create_book_slug($verse_object->book) : sanitize_title($verse_object->book);
                     $verse_url = esc_url(home_url($base_bible_page_uri_search . $book_slug_for_url . "/{$verse_object->chapter}/{$verse_object->verse}/"));
                     $output .= "<p class='verse-text' data-original-text='" . esc_attr($verse_object->text) . "' data-verse-url='" . esc_attr($verse_url) . "'>";
-                    $output .= "<span class='text-content'>" . esc_html($verse_object->text) . "</span> ";
+                    $output .= "<span class='text-content'>" . wp_kses_post($modified_verse_text) . "</span> "; // Use wp_kses_post
                     $output .= "<a href='" . esc_url($verse_url) . "' class='verse-reference-link'>[" . $reference_text . "]</a></p>";
                     $output .= '</div>';
                     $output .= '<div id="verse-image-container" style="margin-top: 20px;"></div>';
                 } else {
                     $output .= '<p>' . sprintf(esc_html__('لم يتم العثور على الشاهد: %s', 'my-bible-plugin'), esc_html($search_term_get)) . '</p>';
                 }
-            } else { 
+            } else { // Full chapter display
+                $dictionary_terms_for_search_chapter = array();
+                 if (!empty($normalized_book_name_for_dict_query)) {
+                    $dictionary_terms_for_search_chapter = $wpdb->get_results($wpdb->prepare(
+                        "SELECT word, meaning FROM %i WHERE book_name = %s AND chapter = %d",
+                        $dict_table_name, $normalized_book_name_for_dict_query, $chapter_num
+                    ));
+                    if ($wpdb->last_error) { if (function_exists('my_bible_log_error')) my_bible_log_error("DB error fetching dictionary terms for chapter (search ref): " . $wpdb->last_error, 'dictionary_highlight'); $dictionary_terms_for_search_chapter = array(); }
+                }
+
                 $verses_in_chapter = $wpdb->get_results($wpdb->prepare( "SELECT book, chapter, verse, text FROM $table_name WHERE book = %s AND chapter = %d ORDER BY verse ASC", $book_name, $chapter_num ));
                 if ($verses_in_chapter) {
                     $output .= '<h2>' . sprintf(esc_html__('عرض الأصحاح: %s %d', 'my-bible-plugin'), esc_html($book_name), $chapter_num) . '</h2>';
@@ -222,12 +294,20 @@ function my_bible_search_form_shortcode($atts) {
                     }
                     $output .= '<div id="verses-content" class="verses-text-container">';
                     foreach ($verses_in_chapter as $verse_obj) {
+                        $modified_verse_text = $verse_obj->text;
+                        if (!empty($dictionary_terms_for_search_chapter)) {
+                            foreach ($dictionary_terms_for_search_chapter as $dict_term) {
+                                $pattern = '/\b(' . preg_quote($dict_term->word, '/') . ')\b/ui';
+                                $replacement = '<span class="dict-term" data-meaning="' . esc_attr($dict_term->meaning) . '">$1</span>';
+                                $modified_verse_text = preg_replace($pattern, $replacement, $modified_verse_text, 1);
+                            }
+                        }
                         $reference = esc_html($verse_obj->book . ' ' . $verse_obj->chapter . ':' . $verse_obj->verse);
                         $book_slug_for_url = function_exists('my_bible_create_book_slug') ? my_bible_create_book_slug($verse_obj->book) : sanitize_title($verse_obj->book);
                         $verse_url = esc_url(home_url($base_bible_page_uri_search . $book_slug_for_url . "/{$verse_obj->chapter}/{$verse_obj->verse}/"));
                         $output .= "<p class='verse-text' data-original-text='" . esc_attr($verse_obj->text) . "' data-verse-url='" . esc_attr($verse_url) . "'>";
                         $output .= "<a href='" . esc_url($verse_url) . "' class='verse-number'>" . esc_html($verse_obj->verse) . ".</a> ";
-                        $output .= "<span class='text-content'>" . esc_html($verse_obj->text) . "</span> ";
+                        $output .= "<span class='text-content'>" . wp_kses_post($modified_verse_text) . "</span> "; // Use wp_kses_post
                         $output .= "<a href='" . esc_url($verse_url) . "' class='verse-reference-link'>[" . $reference . "]</a></p>";
                     }
                     $output .= '</div>';
@@ -235,9 +315,12 @@ function my_bible_search_form_shortcode($atts) {
                     $output .= '<p>' . sprintf(esc_html__('لم يتم العثور على الأصحاح: %s %d', 'my-bible-plugin'), esc_html($book_name), $chapter_num) . '</p>';
                 }
             }
-        } else { 
-            $search_term_cleaned = function_exists('my_bible_sanitize_book_name') ? my_bible_sanitize_book_name($search_term_get) : $search_term_get;
-            $search_term_like = '%' . $wpdb->esc_like($search_term_cleaned) . '%';
+        } else { // Keyword search
+            $search_term_cleaned_for_highlight = function_exists('my_bible_sanitize_book_name') ? my_bible_sanitize_book_name($search_term_get) : $search_term_get; // For highlighting
+            $search_term_for_query = $search_term_cleaned_for_highlight; // Use the same for query text matching
+
+            $search_term_like = '%' . $wpdb->esc_like($search_term_for_query) . '%';
+            // ... (rest of keyword search logic, where_clauses, pagination etc.)
             $where_clauses = array(); $prepare_args = array();
             $where_clauses[] = "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(text, 'ً', ''), 'َ', ''), 'ُ', ''), 'ِ', ''), 'ْ', ''), 'ّ', ''), 'إ', 'ا'), 'أ', 'ا'), 'آ', 'ا') LIKE %s";
             $prepare_args[] = $search_term_like;
@@ -247,7 +330,9 @@ function my_bible_search_form_shortcode($atts) {
             }
             $where_sql = implode(' AND ', $where_clauses);
             $total_results = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM $table_name WHERE $where_sql", $prepare_args));
+
             if ($total_results > 0) {
+                // ... (pagination setup)
                 $results_per_page = apply_filters('my_bible_search_results_per_page', 10);
                 $current_page = isset($_GET['search_page']) ? max(1, intval($_GET['search_page'])) : 1;
                 $offset = ($current_page - 1) * $results_per_page;
@@ -255,32 +340,66 @@ function my_bible_search_form_shortcode($atts) {
                 $prepare_args_paged[] = $results_per_page;
                 $prepare_args_paged[] = $offset;
                 $search_results = $wpdb->get_results($wpdb->prepare("SELECT book, chapter, verse, text FROM $table_name WHERE $where_sql ORDER BY book ASC, chapter ASC, verse ASC LIMIT %d OFFSET %d", $prepare_args_paged));
+
                 $output .= '<h2>' . sprintf(esc_html__('نتائج البحث عن "%s" (%d نتيجة):', 'my-bible-plugin'), esc_html($search_term_get), $total_results) . '</h2>';
                 if (function_exists('my_bible_get_controls_html')) {
                     $output .= my_bible_get_controls_html('search');
                 }
                 $output .= '<div class="verses-text-container search-results-container">';
+
+                // Prepare dictionary terms for all unique book-chapter combinations in results to minimize DB calls
+                $chapter_dictionary_terms_cache = array();
                 foreach ($search_results as $result) {
+                    $cache_key = $result->book . '-' . $result->chapter;
+                    if (!isset($chapter_dictionary_terms_cache[$cache_key])) {
+                        $normalized_book_name_for_dict_query_sr = str_replace(' ', '', function_exists('my_bible_sanitize_book_name') ? my_bible_sanitize_book_name($result->book) : $result->book);
+                        if (!empty($normalized_book_name_for_dict_query_sr)) {
+                             $chapter_dictionary_terms_cache[$cache_key] = $wpdb->get_results($wpdb->prepare(
+                                "SELECT word, meaning FROM %i WHERE book_name = %s AND chapter = %d",
+                                $dict_table_name, $normalized_book_name_for_dict_query_sr, $result->chapter
+                            ));
+                            if ($wpdb->last_error) { if (function_exists('my_bible_log_error')) my_bible_log_error("DB error fetching dictionary terms for search result chapter {$cache_key}: " . $wpdb->last_error, 'dictionary_highlight'); $chapter_dictionary_terms_cache[$cache_key] = array(); }
+                        } else {
+                            $chapter_dictionary_terms_cache[$cache_key] = array();
+                        }
+                    }
+                }
+
+                foreach ($search_results as $result) {
+                    $modified_verse_text = $result->text;
+                    $cache_key = $result->book . '-' . $result->chapter;
+                    $current_verse_dict_terms = isset($chapter_dictionary_terms_cache[$cache_key]) ? $chapter_dictionary_terms_cache[$cache_key] : array();
+
+                    if (!empty($current_verse_dict_terms)) {
+                        foreach ($current_verse_dict_terms as $dict_term) {
+                            // Optional: Add a verse check here if dictionary terms are verse-specific within the chapter results
+                            // if ($dict_term->verse != $result->verse) continue;
+                            $pattern = '/\b(' . preg_quote($dict_term->word, '/') . ')\b/ui';
+                            $replacement = '<span class="dict-term" data-meaning="' . esc_attr($dict_term->meaning) . '">$1</span>';
+                            $modified_verse_text = preg_replace($pattern, $replacement, $modified_verse_text, 1);
+                        }
+                    }
+
+                    // Then apply search term highlighting
+                    $highlighted_text = preg_replace('/(' . preg_quote($search_term_cleaned_for_highlight, '/') . ')/iu', '<mark class="search-highlight">$1</mark>', $modified_verse_text);
+
                     $reference = esc_html($result->book . ' ' . $result->chapter . ':' . $result->verse);
                     $book_slug_for_url = function_exists('my_bible_create_book_slug') ? my_bible_create_book_slug($result->book) : sanitize_title($result->book);
                     $verse_url = esc_url(home_url($base_bible_page_uri_search . $book_slug_for_url . "/{$result->chapter}/{$result->verse}/"));
-                    $verse_text_display = esc_html($result->text);
-                    $highlighted_text = preg_replace('/(' . preg_quote($search_term_cleaned, '/') . ')/iu', '<mark class="search-highlight">$1</mark>', $verse_text_display);
+
                     $output .= "<div class='search-result-item verse-text' data-original-text='" . esc_attr($result->text) . "' data-verse-url='" . esc_attr($verse_url) . "'>";
                     $output .= "<p class='search-result-reference'><a href='" . esc_url($verse_url) . "'>" . $reference . "</a></p>";
-                    $output .= "<p class='search-result-text'><span class='text-content'>" . $highlighted_text . "</span></p>";
+                    $output .= "<p class='search-result-text'><span class='text-content'>" . wp_kses_post($highlighted_text) . "</span></p>"; // Use wp_kses_post
                     $output .= "</div>";
                 }
                 $output .= '</div>';
+                // Pagination
                 $total_pages = ceil($total_results / $results_per_page);
                 if ($total_pages > 1) {
                     $pagination_args = array(
                         'base' => add_query_arg(array('bible_search' => urlencode($search_term_get), 'search_testament' => $search_testament_filter_db, 'search_page' => '%#%'), remove_query_arg('search_page', wp_specialchars_decode(get_permalink()))),
-                        'format' => '',
-                        'current' => $current_page,
-                        'total' => $total_pages,
-                        'prev_text' => __('&laquo; السابق', 'my-bible-plugin'),
-                        'next_text' => __('التالي &raquo;', 'my-bible-plugin'),
+                        'format' => '', 'current' => $current_page, 'total' => $total_pages,
+                        'prev_text' => __('&laquo; السابق', 'my-bible-plugin'), 'next_text' => __('التالي &raquo;', 'my-bible-plugin'),
                         'add_args'  => false,
                     );
                     $output .= '<div class="bible-pagination">' . paginate_links($pagination_args) . '</div>';
@@ -296,9 +415,12 @@ function my_bible_search_form_shortcode($atts) {
 add_shortcode('bible_search', 'my_bible_search_form_shortcode');
 
 function my_bible_random_verse_shortcode($atts) {
-    global $wpdb; $table_name = $wpdb->prefix . 'bible_verses';
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'bible_verses';
+    $dict_table_name = $wpdb->prefix . 'bible_dictionary';
     $options = get_option('my_bible_options');
     $selected_book_for_random = isset($options['bible_random_book']) ? $options['bible_random_book'] : '';
+
     $query = "SELECT book, chapter, verse, text FROM $table_name";
     $prepare_args = array();
     if (!empty($selected_book_for_random)) {
@@ -306,24 +428,46 @@ function my_bible_random_verse_shortcode($atts) {
         $prepare_args[] = $selected_book_for_random;
     }
     $query .= " ORDER BY RAND() LIMIT 1";
+
     if(!empty($prepare_args)){
         $verse_obj = $wpdb->get_row($wpdb->prepare($query, $prepare_args));
     } else {
         $verse_obj = $wpdb->get_row($query);
     }
+
     if ($verse_obj) {
+        $dictionary_terms_for_single_verse = array();
+        $normalized_book_name_for_dict_query = str_replace(' ', '', function_exists('my_bible_sanitize_book_name') ? my_bible_sanitize_book_name($verse_obj->book) : $verse_obj->book);
+        if (!empty($normalized_book_name_for_dict_query)) {
+            $dictionary_terms_for_single_verse = $wpdb->get_results($wpdb->prepare(
+                "SELECT word, meaning FROM %i WHERE book_name = %s AND chapter = %d AND verse = %d",
+                $dict_table_name, $normalized_book_name_for_dict_query, $verse_obj->chapter, $verse_obj->verse
+            ));
+            if ($wpdb->last_error) { if (function_exists('my_bible_log_error')) my_bible_log_error("DB error fetching dictionary terms for random verse: " . $wpdb->last_error, 'dictionary_highlight'); $dictionary_terms_for_single_verse = array(); }
+        }
+
+        $modified_verse_text = $verse_obj->text;
+        if (!empty($dictionary_terms_for_single_verse)) {
+            foreach ($dictionary_terms_for_single_verse as $dict_term) {
+                $pattern = '/\b(' . preg_quote($dict_term->word, '/') . ')\b/ui';
+                $replacement = '<span class="dict-term" data-meaning="' . esc_attr($dict_term->meaning) . '">$1</span>';
+                $modified_verse_text = preg_replace($pattern, $replacement, $modified_verse_text, 1);
+            }
+        }
+
         $reference = esc_html($verse_obj->book . ' ' . $verse_obj->chapter . ':' . $verse_obj->verse);
         $book_slug_for_url = function_exists('my_bible_create_book_slug') ? my_bible_create_book_slug($verse_obj->book) : sanitize_title($verse_obj->book);
         $base_bible_page_uri_rand = trailingslashit(get_page_by_path('bible') ? get_page_uri(get_page_by_path('bible')->ID) : 'bible');
         $verse_url = esc_url(home_url($base_bible_page_uri_rand . $book_slug_for_url . "/{$verse_obj->chapter}/{$verse_obj->verse}/"));
+
         $html = "<div class='random-verse-widget bible-content-area'>";
         $html .= '<h4 style="text-align:center;">' . esc_html__('آية عشوائية', 'my-bible-plugin') . '</h4>';
         if (function_exists('my_bible_get_controls_html')) {
-            $html .= my_bible_get_controls_html('random_verse', $verse_obj, $reference); // استخدام سياق random_verse
+            $html .= my_bible_get_controls_html('random_verse', $verse_obj, $reference);
         }
         $html .= "<div class='verse-text-container'>";
         $html .= "<p class='verse-text random-verse' data-original-text='" . esc_attr($verse_obj->text) . "' data-verse-url='" . esc_attr($verse_url) . "'>";
-        $html .= "<span class='text-content'>" . esc_html($verse_obj->text) . "</span> ";
+        $html .= "<span class='text-content'>" . wp_kses_post($modified_verse_text) . "</span> "; // Use wp_kses_post
         $html .= "<a href='" . esc_url($verse_url) . "' class='verse-reference-link'>[" . $reference . "]</a></p>";
         $html .= "</div>";
         $html .= '<div id="verse-image-container" style="margin-top: 20px;"></div>';
@@ -335,14 +479,18 @@ function my_bible_random_verse_shortcode($atts) {
 add_shortcode('random_verse', 'my_bible_random_verse_shortcode');
 
 function my_bible_daily_verse_shortcode($atts) {
-    global $wpdb; $table_name = $wpdb->prefix . 'bible_verses';
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'bible_verses';
+    $dict_table_name = $wpdb->prefix . 'bible_dictionary';
     $options = get_option('my_bible_options');
     $selected_book_for_daily = isset($options['bible_random_book']) ? $options['bible_random_book'] : '';
     $current_date_key_suffix = !empty($selected_book_for_daily) ? '_' . sanitize_key($selected_book_for_daily) : '';
     $transient_key = 'daily_verse_' . date('Y-m-d') . $current_date_key_suffix;
     $verse_data_transient = get_transient($transient_key);
-    $verse_object_for_controls = null; 
+    $verse_object_for_controls = null;
+
     if (false === $verse_data_transient) {
+        // ... (logic to fetch and set transient for daily verse as before) ...
         $query = "SELECT id, book, chapter, verse, text FROM $table_name";
         $prepare_args_daily = array();
         if (!empty($selected_book_for_daily)) {
@@ -357,7 +505,7 @@ function my_bible_daily_verse_shortcode($atts) {
         }
         if ($verse_obj_daily) {
             $verse_data_transient = array( 'book' => $verse_obj_daily->book, 'chapter' => $verse_obj_daily->chapter, 'verse' => $verse_obj_daily->verse, 'text' => $verse_obj_daily->text );
-            $verse_object_for_controls = $verse_obj_daily;
+            $verse_object_for_controls = $verse_obj_daily; // Use the actual object here
             set_transient($transient_key, $verse_data_transient, DAY_IN_SECONDS);
         } else {
             set_transient($transient_key, array('empty' => true), DAY_IN_SECONDS);
@@ -365,26 +513,48 @@ function my_bible_daily_verse_shortcode($atts) {
         }
     } elseif (isset($verse_data_transient['empty'])) {
          return '<p class="daily-verse-widget">' . esc_html__('لم يتم تحديد آية اليوم بعد (بيانات فارغة مخزنة).', 'my-bible-plugin') . '</p>';
-    } else {
+    } else { // Construct object from transient data
         $verse_object_for_controls = new stdClass();
         $verse_object_for_controls->book = $verse_data_transient['book'];
         $verse_object_for_controls->chapter = $verse_data_transient['chapter'];
         $verse_object_for_controls->verse = $verse_data_transient['verse'];
         $verse_object_for_controls->text = $verse_data_transient['text'];
     }
+
     if ($verse_object_for_controls) {
+        $dictionary_terms_for_single_verse = array();
+        $normalized_book_name_for_dict_query = str_replace(' ', '', function_exists('my_bible_sanitize_book_name') ? my_bible_sanitize_book_name($verse_object_for_controls->book) : $verse_object_for_controls->book);
+        if (!empty($normalized_book_name_for_dict_query)) {
+            $dictionary_terms_for_single_verse = $wpdb->get_results($wpdb->prepare(
+                "SELECT word, meaning FROM %i WHERE book_name = %s AND chapter = %d AND verse = %d",
+                $dict_table_name, $normalized_book_name_for_dict_query, $verse_object_for_controls->chapter, $verse_object_for_controls->verse
+            ));
+            if ($wpdb->last_error) { if (function_exists('my_bible_log_error')) my_bible_log_error("DB error fetching dictionary terms for daily verse: " . $wpdb->last_error, 'dictionary_highlight'); $dictionary_terms_for_single_verse = array(); }
+        }
+
+        $modified_verse_text = $verse_object_for_controls->text;
+        if (!empty($dictionary_terms_for_single_verse)) {
+            foreach ($dictionary_terms_for_single_verse as $dict_term) {
+                $pattern = '/\b(' . preg_quote($dict_term->word, '/') . ')\b/ui';
+                $replacement = '<span class="dict-term" data-meaning="' . esc_attr($dict_term->meaning) . '">$1</span>';
+                $modified_verse_text = preg_replace($pattern, $replacement, $modified_verse_text, 1);
+            }
+        }
+
         $reference = esc_html($verse_object_for_controls->book . ' ' . $verse_object_for_controls->chapter . ':' . $verse_object_for_controls->verse);
         $book_slug_for_url = function_exists('my_bible_create_book_slug') ? my_bible_create_book_slug($verse_object_for_controls->book) : sanitize_title($verse_object_for_controls->book);
         $base_bible_page_uri_daily = trailingslashit(get_page_by_path('bible') ? get_page_uri(get_page_by_path('bible')->ID) : 'bible');
         $verse_url = esc_url(home_url($base_bible_page_uri_daily . $book_slug_for_url . "/{$verse_object_for_controls->chapter}/{$verse_object_for_controls->verse}/"));
+
         $html = "<div class='daily-verse-widget bible-content-area'>";
         $html .= "<h4>" . esc_html__('آية اليوم', 'my-bible-plugin') . "</h4>";
         if (function_exists('my_bible_get_controls_html')) {
-            $html .= my_bible_get_controls_html('daily_verse', $verse_object_for_controls, $reference); // استخدام سياق daily_verse
+            // Pass the original $verse_object_for_controls which might be stdClass or original DB object
+            $html .= my_bible_get_controls_html('daily_verse', $verse_object_for_controls, $reference);
         }
         $html .= "<div class='verse-text-container'>";
         $html .= "<p class='verse-text daily-verse' data-original-text='" . esc_attr($verse_object_for_controls->text) . "' data-verse-url='" . esc_attr($verse_url) . "'>";
-        $html .= "<span class='text-content'>" . esc_html($verse_object_for_controls->text) . "</span> ";
+        $html .= "<span class='text-content'>" . wp_kses_post($modified_verse_text) . "</span> "; // Use wp_kses_post
         $html .= "<a href='" . esc_url($verse_url) . "' class='verse-reference-link'>[" . $reference . "]</a></p>";
         $html .= "</div>";
         $html .= '<div id="verse-image-container" style="margin-top: 20px;"></div>';
@@ -433,7 +603,7 @@ function my_bible_index_shortcode($atts) {
         }
         $output .= '</ul></div>';
     }
-    $output .= '</div>'; 
+    $output .= '</div>';
     if (!empty($other_books)) {
         $output .= '<div class="bible-testament-section other-books">';
         $output .= '<h2>' . esc_html__('أسفار إضافية / أخرى', 'my-bible-plugin') . '</h2>';
@@ -445,7 +615,7 @@ function my_bible_index_shortcode($atts) {
         }
         $output .= '</ul></div>';
     }
-    $output .= '</div>'; 
+    $output .= '</div>';
     return $output;
 }
 add_shortcode('bible_index', 'my_bible_index_shortcode');

--- a/my-bible-plugin.php
+++ b/my-bible-plugin.php
@@ -37,6 +37,7 @@ function my_bible_enqueue_scripts() {
         wp_enqueue_style('font-awesome', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css', array(), '5.15.4');
         wp_enqueue_style('my-bible-styles', MY_BIBLE_PLUGIN_URL . 'assets/css/bible-styles.css', array(), MY_BIBLE_PLUGIN_VERSION);
         wp_enqueue_style('my-bible-dark-mode', MY_BIBLE_PLUGIN_URL . 'assets/css/dark-mode.css', array('my-bible-styles'), MY_BIBLE_PLUGIN_VERSION);
+        wp_enqueue_style('my-bible-dictionary-styles', MY_BIBLE_PLUGIN_URL . 'assets/css/dictionary-styles.css', array('my-bible-styles'), MY_BIBLE_PLUGIN_VERSION); // Dictionary styles
         wp_enqueue_script('my-bible-frontend', MY_BIBLE_PLUGIN_URL . 'assets/js/bible-frontend.js', array('jquery'), MY_BIBLE_PLUGIN_VERSION, true);
         wp_enqueue_script('my-bible-copy', MY_BIBLE_PLUGIN_URL . 'assets/js/bible-copy.js', array(), MY_BIBLE_PLUGIN_VERSION, true);
 
@@ -56,11 +57,11 @@ function my_bible_enqueue_scripts() {
         }
 
         $bible_page_for_url = get_page_by_path('bible');
-        $base_url_path = 'bible'; 
+        $base_url_path = 'bible';
         if ($bible_page_for_url instanceof WP_Post) {
             $base_url_path = get_page_uri($bible_page_for_url->ID);
         }
-        
+
         $image_fonts_data_php = array(
             'noto_naskh_arabic' => array('label' => __('خط نسخ (افتراضي)', 'my-bible-plugin'), 'family' => '"Noto Naskh Arabic", Arial, Tahoma, sans-serif'),
             'amiri' => array('label' => __('خط أميري', 'my-bible-plugin'), 'family' => 'Amiri, Georgia, serif'),
@@ -91,7 +92,45 @@ function my_bible_enqueue_scripts() {
                 'download_image' => __('تحميل الصورة', 'my-bible-plugin'),
                 'website_credit' => get_bloginfo('name'),
             ),
-            'localized_strings' => array( /* ... array content ... */ )
+            'localized_strings' => array(
+                'loading' => __('جارٍ التحميل...', 'my-bible-plugin'),
+                'please_select_book_and_chapter' => __('يرجى اختيار السفر ثم الأصحاح لعرض الآيات.', 'my-bible-plugin'),
+                'please_select_chapter' => __('يرجى اختيار الأصحاح.', 'my-bible-plugin'),
+                'select_book' => __('اختر السفر', 'my-bible-plugin'),
+                'select_chapter' => __('اختر الأصحاح', 'my-bible-plugin'),
+                'no_books_found' => __('لا توجد أسفار لهذا العهد', 'my-bible-plugin'),
+                'error_loading_books' => __('خطأ في تحميل الأسفار', 'my-bible-plugin'),
+                'no_chapters_found' => __('لم يتم العثور على أصحاحات لهذا السفر.', 'my-bible-plugin'),
+                'error_loading_chapters' => __('حدث خطأ أثناء تحميل الأصحاحات.', 'my-bible-plugin'),
+                'error_loading_chapters_ajax' => __('خطأ في الاتصال (أصحاحات). حاول مرة أخرى.', 'my-bible-plugin'),
+                'error_loading_verses' => __('حدث خطأ أثناء تحميل الآيات.', 'my-bible-plugin'),
+                'error_loading_verses_ajax' => __('خطأ في الاتصال (آيات). حاول مرة أخرى.', 'my-bible-plugin'),
+                'mainPageTitle' => __('الكتاب المقدس', 'my-bible-plugin'),
+                'mainPageDescription' => __('تصفح الكتاب المقدس وقراءة النصوص المقدسة.', 'my-bible-plugin'),
+                'all' => __('الكل', 'my-bible-plugin'),
+                'font_noto_naskh' => __('خط نسخ (افتراضي)', 'my-bible-plugin'),
+                'font_amiri' => __('خط أميري', 'my-bible-plugin'),
+                'font_tahoma' => __('خط تاهوما', 'my-bible-plugin'),
+                'font_arial' => __('خط آريال', 'my-bible-plugin'),
+                'font_times' => __('خط تايمز نيو رومان', 'my-bible-plugin'),
+                'bg_gradient_purple_blue' => __('تدرج بنفسجي-أزرق', 'my-bible-plugin'),
+                'bg_gradient_blue_green' => __('تدرج أزرق-أخضر', 'my-bible-plugin'),
+                'bg_solid_dark_grey' => __('رمادي داكن ثابت', 'my-bible-plugin'),
+                'bg_solid_light_beige' => __('بيج فاتح ثابت', 'my-bible-plugin'),
+                'speech_unsupported' => __('عذراً، متصفحك لا يدعم ميزة القراءة الصوتية.', 'my-bible-plugin'),
+                'no_text_to_read' => __('لا يوجد نص للقراءة.', 'my-bible-plugin'),
+                'error_reading_aloud' => __('حدث خطأ أثناء محاولة القراءة: ', 'my-bible-plugin'),
+                'read_aloud_label' => __('قراءة بصوت عالٍ', 'my-bible-plugin'),
+                'stop_reading_label' => __('إيقاف القراءة', 'my-bible-plugin'),
+                'show_tashkeel_label' => __('إظهار التشكيل', 'my-bible-plugin'),
+                'hide_tashkeel_label' => __('إلغاء التشكيل', 'my-bible-plugin'),
+                'dark_mode_toggle_label_light' => __('الوضع النهاري', 'my-bible-plugin'),
+                'dark_mode_toggle_label_dark' => __('الوضع الليلي', 'my-bible-plugin'),
+                // New strings for chapter meanings modal
+                'chapter_meanings_title' => __('معاني كلمات الأصحاح', 'my-bible-plugin'),
+                'no_dictionary_terms_in_chapter' => __('لا توجد كلمات من القاموس في هذا الأصحاح.', 'my-bible-plugin'),
+                'no_chapter_content' => __('لم يتم العثور على محتوى الأصحاح.', 'my-bible-plugin'),
+            )
         );
 
         wp_localize_script('my-bible-frontend', 'bibleFrontend', $frontend_data);
@@ -107,8 +146,148 @@ if (file_exists(MY_BIBLE_PLUGIN_DIR . 'includes/shortcodes.php')) { require_once
 if (file_exists(MY_BIBLE_PLUGIN_DIR . 'includes/ajax.php')) { require_once MY_BIBLE_PLUGIN_DIR . 'includes/ajax.php'; }
 if (file_exists(MY_BIBLE_PLUGIN_DIR . 'includes/sitemap.php')) { require_once MY_BIBLE_PLUGIN_DIR . 'includes/sitemap.php'; }
 
+function my_bible_create_dictionary_table_and_import_data() {
+    global $wpdb;
+    $table_name = $wpdb->prefix . 'bible_dictionary';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    // SQL schema for the dictionary table
+    $sql = "CREATE TABLE $table_name (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        dictionary_key VARCHAR(255) NOT NULL,
+        book_name VARCHAR(255) NOT NULL,
+        chapter INT NOT NULL,
+        verse INT NOT NULL,
+        word TEXT NOT NULL,
+        meaning TEXT NOT NULL,
+        PRIMARY KEY (id),
+        UNIQUE KEY dictionary_key (dictionary_key),
+        KEY book_chapter_verse (book_name(191), chapter, verse)
+    ) $charset_collate;";
+
+    require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+    dbDelta($sql);
+
+    // Helper function to parse VerseID
+    if (!function_exists('_my_bible_parse_verse_id')) {
+        function _my_bible_parse_verse_id($verse_id_str) {
+            // Normalize common Arabic characters for broader matching
+            $verse_id_str = str_replace(['أ', 'إ', 'آ'], 'ا', $verse_id_str);
+            $verse_id_str = str_replace('ى', 'ي', $verse_id_str);
+            $verse_id_str = trim($verse_id_str);
+
+            // Define book name map (abbreviation -> full name)
+            $book_map = array(
+                'تك' => 'سفر التكوين', 'خر' => 'سفر الخروج', 'لاو' => 'سفر اللاويين', 'عد' => 'سفر العدد', 'تث' => 'سفر التثنية',
+                'يش' => 'سفر يشوع', 'قض' => 'سفر القضاة', 'را' => 'سفر راعوث', '1صم' => 'سفر صموئيل الأول', '2صم' => 'سفر صموئيل الثاني',
+                '1مل' => 'سفر الملوك الأول', '2مل' => 'سفر الملوك الثاني', '1اخ' => 'سفر أخبار الأيام الأول', '2اخ' => 'سفر أخبار الأيام الثاني',
+                'عز' => 'سفر عزرا', 'نح' => 'سفر نحميا', 'اس' => 'سفر أستير', 'اي' => 'سفر أيوب', 'مز' => 'سفر المزامير',
+                'ام' => 'سفر الأمثال', 'جا' => 'سفر الجامعة', 'نش' => 'سفر نشيد الأنشاد', 'اش' => 'سفر إشعياء', 'ار' => 'سفر إرميا',
+                'مرا' => 'سفر مراثي إرميا', 'حز' => 'سفر حزقيال', 'دا' => 'سفر دانيال', 'هو' => 'سفر هوشع', 'يؤ' => 'سفر يوئيل',
+                'عا' => 'سفر عاموس', 'عو' => 'سفر عوبديا', 'يون' => 'سفر يونان', 'مي' => 'سفر ميخا', 'نا' => 'سفر ناحوم',
+                'حب' => 'سفر حبقوق', 'صف' => 'سفر صفنيا', 'حج' => 'سفر حجي', 'زك' => 'سفر زكريا', 'ملا' => 'سفر ملاخي',
+                'مت' => 'إنجيل متى', 'مر' => 'إنجيل مرقس', 'لو' => 'إنجيل لوقا', 'يو' => 'إنجيل يوحنا', 'اع' => 'سفر أعمال الرسل',
+                'رو' => 'الرسالة إلى أهل رومية', '1كو' => 'الرسالة الأولى إلى أهل كورنثوس', '2كو' => 'الرسالة الثانية إلى أهل كورنثوس',
+                'غل' => 'الرسالة إلى أهل غلاطية', 'اف' => 'الرسالة إلى أهل أفسس', 'في' => 'الرسالة إلى أهل فيلبي', 'كو' => 'الرسالة إلى أهل كولوسي',
+                '1تس' => 'الرسالة الأولى إلى أهل تسالونيكي', '2تس' => 'الرسالة الثانية إلى أهل تسالونيكي', '1تي' => 'الرسالة الأولى إلى تيموثاوس',
+                '2تي' => 'الرسالة الثانية إلى تيموثاوس', 'تي' => 'الرسالة إلى تيطس', 'فل' => 'الرسالة إلى فليمون', 'عب' => 'الرسالة إلى العبرانيين',
+                'يع' => 'رسالة يعقوب', '1بط' => 'رسالة بطرس الأولى', '2بط' => 'رسالة بطرس الثانية', '1يو' => 'رسالة يوحنا الأولى',
+                '2يو' => 'رسالة يوحنا الثانية', '3يو' => 'رسالة يوحنا الثالثة', 'يه' => 'رسالة يهوذا', 'رؤ' => 'سفر رؤيا يوحنا اللاهوتي'
+            );
+
+            // Regex to extract book abbreviation/name, chapter, and verse
+            if (preg_match('/^([^\d\s]+(?:\d[^\s\d]*)?)\s*(\d+)\s*:\s*(\d+)$/u', $verse_id_str, $matches)) {
+                $book_abbr = trim($matches[1]);
+                $chapter = (int)$matches[2];
+                $verse = (int)$matches[3];
+
+                // Normalize abbreviation before map lookup (standardize characters, then tolower)
+                $normalized_book_abbr = str_replace(['أ', 'إ', 'آ'], 'ا', $book_abbr);
+                $normalized_book_abbr = str_replace('ى', 'ي', $normalized_book_abbr);
+                $normalized_book_abbr = strtolower($normalized_book_abbr);
+
+                $book_name = isset($book_map[$normalized_book_abbr]) ? $book_map[$normalized_book_abbr] : $book_abbr; // Fallback to abbr
+
+                // Normalize the full book name for storage (remove all spaces, specific chars already handled)
+                $final_book_name = str_replace(' ', '', $book_name);
+                $final_book_name = str_replace(['أ', 'إ', 'آ'], 'ا', $final_book_name);
+                $final_book_name = str_replace('ى', 'ي', $final_book_name);
+
+
+                return ['book' => $final_book_name, 'chapter' => $chapter, 'verse' => $verse];
+            } else {
+                my_bible_log_error("Failed to parse VerseID: " . $verse_id_str, 'dictionary_import');
+                return false;
+            }
+        }
+    }
+
+    $csv_file_path = MY_BIBLE_PLUGIN_DIR . 'assets/data/dictionary_data.csv';
+
+    if (file_exists($csv_file_path) && is_readable($csv_file_path)) {
+        if (($handle = fopen($csv_file_path, 'r')) !== FALSE) {
+            fgetcsv($handle); // Skip header
+
+            while (($row = fgetcsv($handle)) !== FALSE) {
+                if (count($row) < 4) { // Expect at least ID, VerseID, Word, Meaning
+                    my_bible_log_error("Skipping row due to insufficient columns: " . implode(',', $row), 'dictionary_import');
+                    continue;
+                }
+
+                // $csv_id = trim($row[0]); // Column 0 is ID
+                $verse_id_str = trim($row[1]); // Column 1 is VerseID
+                $word = trim(stripslashes($row[2])); // Column 2 is Word
+                $meaning = trim(stripslashes($row[3])); // Column 3 is Meaning
+
+                if (empty($verse_id_str) || empty($word) || empty($meaning)) {
+                    my_bible_log_error("Skipping row due to empty essential data. VerseID: '{$verse_id_str}', Word: '{$word}'", 'dictionary_import');
+                    continue;
+                }
+
+                $parsed_verse_id = _my_bible_parse_verse_id($verse_id_str);
+
+                if ($parsed_verse_id) {
+                    // Book name from parser is already normalized (no spaces, standard chars)
+                    $normalized_key_book_name = strtolower($parsed_verse_id['book']);
+                    $normalized_key_word = strtolower($word);
+
+                    // Construct the string for MD5 hash to ensure consistency
+                    $dictionary_key_string = $normalized_key_book_name . '-' . $parsed_verse_id['chapter'] . '-' . $parsed_verse_id['verse'] . '-' . $normalized_key_word;
+                    $dictionary_key = md5($dictionary_key_string);
+
+                    $existing = $wpdb->get_var($wpdb->prepare("SELECT id FROM $table_name WHERE dictionary_key = %s", $dictionary_key));
+
+                    if (!$existing) {
+                        $insert_result = $wpdb->insert(
+                            $table_name,
+                            array(
+                                'dictionary_key' => $dictionary_key,
+                                'book_name' => $parsed_verse_id['book'], // Use the full, normalized book name from parser
+                                'chapter' => $parsed_verse_id['chapter'],
+                                'verse' => $parsed_verse_id['verse'],
+                                'word' => $word,
+                                'meaning' => $meaning
+                            ),
+                            array('%s', '%s', '%d', '%d', '%s', '%s')
+                        );
+                        if ($insert_result === false) {
+                            my_bible_log_error("DB Insert Error for dictionary key {$dictionary_key} (VerseID: {$verse_id_str}, Word: {$word}): " . $wpdb->last_error, 'dictionary_import');
+                        }
+                    }
+                }
+            }
+            fclose($handle);
+        } else {
+            my_bible_log_error("Failed to open CSV file: " . $csv_file_path, 'dictionary_import');
+        }
+    } else {
+        my_bible_log_error("CSV file not found or not readable: " . $csv_file_path, 'dictionary_import');
+    }
+}
+
 function my_bible_create_table() { /* ... كما كان ... */ }
 register_activation_hook(__FILE__, 'my_bible_create_table');
+register_activation_hook(__FILE__, 'my_bible_create_dictionary_table_and_import_data');
 
 function my_bible_create_pages() { /* ... كما كان ... */ }
 register_activation_hook(__FILE__, 'my_bible_create_pages');
@@ -127,14 +306,14 @@ add_action('admin_init', 'my_bible_register_settings');
 
 function my_bible_general_settings_section_callback() { echo '<p>' . esc_html__('اختر الإعدادات العامة لإضافة الكتاب المقدس.', 'my-bible-plugin') . '</p>'; }
 
-function my_bible_random_book_field_callback() { 
-    global $wpdb; $options = get_option('my_bible_options'); $selected_book = isset($options['bible_random_book']) ? $options['bible_random_book'] : ''; $table_name = $wpdb->prefix . 'bible_verses'; 
+function my_bible_random_book_field_callback() {
+    global $wpdb; $options = get_option('my_bible_options'); $selected_book = isset($options['bible_random_book']) ? $options['bible_random_book'] : ''; $table_name = $wpdb->prefix . 'bible_verses';
     $books = $wpdb->get_col("SELECT DISTINCT book FROM $table_name ORDER BY book ASC");
-    if ($wpdb->last_error) { my_bible_log_error($wpdb->last_error, 'Settings - loading random books'); echo '<p>' . esc_html__('خطأ في جلب قائمة الأسفار.', 'my-bible-plugin') . '</p>'; return; } 
-    if (empty($books)) { echo '<p>' . esc_html__('لم يتم العثور على أسفار في قاعدة البيانات.', 'my-bible-plugin') . '</p>'; return; } 
-    echo '<select id="bible_random_book_select" name="my_bible_options[bible_random_book]">'; echo '<option value="">' . esc_html__('كل الأسفار', 'my-bible-plugin') . '</option>'; 
-    foreach ($books as $book) { echo '<option value="' . esc_attr($book) . '" ' . selected($selected_book, $book, false) . '>' . esc_html($book) . '</option>'; } 
-    echo '</select>'; echo '<p class="description">' . esc_html__('اختر سفراً للآيات العشوائية واليومية.', 'my-bible-plugin') . '</p>'; 
+    if ($wpdb->last_error) { my_bible_log_error($wpdb->last_error, 'Settings - loading random books'); echo '<p>' . esc_html__('خطأ في جلب قائمة الأسفار.', 'my-bible-plugin') . '</p>'; return; }
+    if (empty($books)) { echo '<p>' . esc_html__('لم يتم العثور على أسفار في قاعدة البيانات.', 'my-bible-plugin') . '</p>'; return; }
+    echo '<select id="bible_random_book_select" name="my_bible_options[bible_random_book]">'; echo '<option value="">' . esc_html__('كل الأسفار', 'my-bible-plugin') . '</option>';
+    foreach ($books as $book) { echo '<option value="' . esc_attr($book) . '" ' . selected($selected_book, $book, false) . '>' . esc_html($book) . '</option>'; }
+    echo '</select>'; echo '<p class="description">' . esc_html__('اختر سفراً للآيات العشوائية واليومية.', 'my-bible-plugin') . '</p>';
 }
 
 function my_bible_default_dark_mode_field_callback() { /* ... كما كان ... */ }
@@ -143,3 +322,5 @@ function my_bible_options_sanitize($input) { /* ... كما كان ... */ return 
 function my_bible_settings_page_content() { /* ... كما كان ... */ }
 add_filter('widget_text', 'do_shortcode');
 ?>
+
+[end of my-bible-plugin.php]


### PR DESCRIPTION
This commit introduces a comprehensive Bible dictionary feature into the plugin.

Key functionalities include:

1.  Dictionary Data Import:
    *   On plugin activation, a new database table `wp_bible_dictionary` is created.
    *   Data from `assets/data/dictionary_data.csv` is parsed and imported into this table. This includes robust parsing of `VerseID` strings (e.g., "تك1:2") to link terms to specific Bible book names, chapters, and verses, with normalization of book names.
    *   A unique key is generated for each dictionary entry to prevent duplicates during import.

2.  In-Text Word Highlighting:
    *   Dictionary terms found within Bible verse text (in full chapter views, search results, random/daily verses) are now highlighted.
    *   Highlighted terms are wrapped in `<span class="dict-term">` and include a `data-meaning` attribute containing their definition.

3.  Interactive Tooltips:
    *   Hovering over a highlighted dictionary term displays its meaning in a JavaScript-powered tooltip.
    *   Custom CSS styles are provided for the highlighted terms and the tooltips, including dark mode support, in a new `assets/css/dictionary-styles.css` file.

4.  "Show Meanings for Chapter" Button:
    *   A new button is added to the Bible controls ("إظهار معاني كلمات الأصحاح").
    *   Clicking this button displays a modal dialog containing all unique dictionary terms and their meanings found in the currently viewed chapter.
    *   The modal is styled with CSS and includes dark mode support.

5.  Localization:
    *   New user-facing strings for the dictionary feature (e.g., modal title, button text) have been added and localized.

This integration enhances the plugin by providing you with quick access to definitions and explanations of specific words within the Bible text, enriching your study experience.